### PR TITLE
Fix build with kernel after 2.6.39.

### DIFF
--- a/dpdk-2.0.0/lib/librte_eal/linuxapp/igb_uio/igb_uio.c
+++ b/dpdk-2.0.0/lib/librte_eal/linuxapp/igb_uio/igb_uio.c
@@ -85,7 +85,7 @@ store_max_vfs(struct device *dev, struct device_attribute *attr,
 	unsigned long max_vfs;
 	struct pci_dev *pdev = container_of(dev, struct pci_dev, dev);
 
-	if (0 != strict_strtoul(buf, 0, &max_vfs))
+	if (0 != kstrtoul(buf, 0, &max_vfs))
 		return -EINVAL;
 
 	if (0 == max_vfs)
@@ -176,7 +176,7 @@ store_max_read_request_size(struct device *dev,
 	unsigned long size = 0;
 	int ret;
 
-	if (strict_strtoul(buf, 0, &size) != 0)
+	if (0 != kstrtoul(buf, 0, &size))
 		return -EINVAL;
 
 	ret = pcie_set_readrq(pci_dev, (int)size);


### PR DESCRIPTION
This code has macros to define `kstrtoul` as `strict_strtoul` for kernel before 2.6.39 but in one place use direct `strict_strtoul`.