### PR TITLE
mtcp/src/eventpoll.c some mistake

### DIFF
--- a/apps/lighttpd-1.4.32/src/server.c
+++ b/apps/lighttpd-1.4.32/src/server.c
@@ -1905,6 +1905,7 @@ main(int argc, char **argv) {
 
 	/* This part of code is only executed in the single-process, single-threaded version (non-mtcp/non-multithreaded) */
 	/* Under USE_MTCP settings, each individual `running_thread' executes the `main-loop' */
+	/* In USE_MTCP settings main thread will execute the flowing step */
 	/* main-loop */
 	while (!srv_shutdown) {
 		int n;

--- a/mtcp/src/eventpoll.c
+++ b/mtcp/src/eventpoll.c
@@ -127,7 +127,7 @@ mtcp_epoll_create(mctx_t mctx, int size)
 		return -1;
 	}
 
-	TRACE_EPOLL("epoll structure of size %d created.\n", ep->size);
+	TRACE_EPOLL("epoll structure of size %d created.\n", size);
 
 	mtcp->ep = ep;
 	epsocket->ep = ep;


### PR DESCRIPTION
In "mtcp/src/eventpoll.c+130" epoll structure has no member size ,this should be "mtcp_epoll_create" size

in  "lighttppd-1.4.32" add a notes to make a distinction between slave thread and master thread