### PR TITLE
fix 2 bugs: PrintNetworkStats is undefined if not define macro NETSTAT 

### DIFF
--- a/dpdk-16.04/mk/rte.app.mk
+++ b/dpdk-16.04/mk/rte.app.mk
@@ -207,8 +207,11 @@ else
 O_TO_EXE = $(LD) $(LDFLAGS) $(LDFLAGS_$(@)) $(EXTRA_LDFLAGS) \
 	-Map=$(@).map --cref -o $@ $(OBJS-y) $(LDLIBS)
 endif
+
+$(shell if [ ! -d ${RTE_SDK}/${RTE_TARGET}/lib ]; then mkdir ${RTE_SDK}/${RTE_TARGET}/lib; fi)
 LINKER_FLAGS = $(call linkerprefix,$(LDLIBS))
 $(shell echo ${LINKER_FLAGS} > ${RTE_SDK}/${RTE_TARGET}/lib/ldflags.txt)
+
 O_TO_EXE_STR = $(subst ','\'',$(O_TO_EXE)) #'# fix syntax highlight
 O_TO_EXE_DISP = $(if $(V),"$(O_TO_EXE_STR)","  LD $(@)")
 O_TO_EXE_CMD = "cmd_$@ = $(O_TO_EXE_STR)"

--- a/mtcp/src/core.c
+++ b/mtcp/src/core.c
@@ -820,7 +820,9 @@ RunMainLoop(struct mtcp_thread_context *ctx)
 			ts_prev = ts;
 			if (ctx->cpu == mtcp_master) {
 				ARPTimer(mtcp, ts);
+#ifdef NETSTAT
 				PrintNetworkStats(mtcp, ts);
+#endif
 			}
 		}
 


### PR DESCRIPTION
fix 2 bugs: 
1) PrintNetworkStats is undefined if not define macro NETSTAT in mtcp/src/core.c
2) before write to lib/ldflags.txt, directory lib should be exist in dpdk-16.04/mk/rte.app.mk