### PR TITLE
Fix mtcp_epoll_wait() timeout processing.

### DIFF
--- a/mtcp/src/eventpoll.c
+++ b/mtcp/src/eventpoll.c
@@ -386,12 +386,13 @@ wait:
 			struct timespec deadline;
 
 			clock_gettime(CLOCK_REALTIME, &deadline);
-			if (timeout > 1000) {
+			if (timeout >= 1000) {
 				int sec;
 				sec = timeout / 1000;
 				deadline.tv_sec += sec;
 				timeout -= sec * 1000;
 			}
+			deadline.tv_nsec += timeout*1000000;
 
 			if (deadline.tv_nsec >= 1000000000) {
 				deadline.tv_sec++;


### PR DESCRIPTION
Fixed an issue where mtcp_epoll_wait() always returns immediately when timeout is set to 1000 or below.