### PR TITLE
Small bug fixes

### DIFF
--- a/mtcp/src/api.c
+++ b/mtcp/src/api.c
@@ -653,6 +653,13 @@ mtcp_init_rss(mctx_t mctx, in_addr_t saddr_base, int num_addr,
 		return -1;
 	}
 
+	if (mtcp->ap) {
+		TRACE_DBG("Destroying already exsiting address pool.\n"
+		          "Are you calling mtcp_init_rss() multiple times?\n");
+		DestroyAddressPool(mtcp->ap);
+		mtcp->ap = NULL;
+	}
+
 	if (saddr_base == INADDR_ANY) {
 		int nif_out, eidx;
 

--- a/mtcp/src/config.c
+++ b/mtcp/src/config.c
@@ -21,6 +21,7 @@
 /* for if_nametoindex */
 #include <net/if.h>
 
+#define MAX_ROUTE_ENTRY 64
 #define MAX_OPTLINE_LEN 1024
 #define ALL_STRING "all"
 
@@ -88,8 +89,8 @@ EnrollRouteTableEntry(char *optstr)
 	int ifidx;
 	int ridx;
 	int i;
-	char * saveptr;
-
+	char *saveptr;
+ 
 	saveptr = NULL;
 	daddr_s = strtok_r(optstr, "/", &saveptr);
 	prefix = strtok_r(NULL, " ", &saveptr);
@@ -123,6 +124,12 @@ EnrollRouteTableEntry(char *optstr)
 	}
 
 	ridx = CONFIG.routes++;
+	if (ridx == MAX_ROUTE_ENTRY) {
+		TRACE_CONFIG("Maximum routing entry limit (%d) has been reached."
+		             "Consider increasing MAX_ROUTE_ENTRY.\n", MAX_ROUTE_ENTRY);
+		exit(4);
+	}
+
 	CONFIG.rtable[ridx].daddr = inet_addr(daddr_s);
 	CONFIG.rtable[ridx].prefix = mystrtol(prefix, 10);
 	if (CONFIG.rtable[ridx].prefix > 32 || CONFIG.rtable[ridx].prefix < 0) {
@@ -157,7 +164,7 @@ SetRoutingTableFromFile()
 	while (1) {
 		char *iscomment;
 		int num;
-
+  
 		if (fgets(optstr, MAX_OPTLINE_LEN, fc) == NULL)
 			break;
 
@@ -272,7 +279,7 @@ SetRoutingTable()
 
 	CONFIG.routes = 0;
 	CONFIG.rtable = (struct route_table *)
-			calloc(MAX_DEVICES, sizeof(struct route_table));
+			calloc(MAX_ROUTE_ENTRY, sizeof(struct route_table));
 	if (!CONFIG.rtable) 
 		exit(EXIT_FAILURE);
 


### PR DESCRIPTION
This pull request addresses two bugs in mTCP.

1) segmentation fault under more than 8 route entries given
Previous code does not verify whether configured route entry exceeds number of buffers allocated for route entry.
To tackle the problem, I've added new constant "MAX_ROUTE_ENTRY" and change the code to verify number of configured route entries and allowed maximum value.

2) memory leak when mtcp_init_rss() has been called multiple times in a core
Current implementation does not verify whether previously created address pool exists or not.
As a quick fix, this patch would make the program to destroy the previous pool before setting up newly allocated pool.
This behavior is undocumented side of mTCP and can change to support initializing rss ports for multiple destination.